### PR TITLE
Fixed struct bug from missing types

### DIFF
--- a/ida/ida_export.py
+++ b/ida/ida_export.py
@@ -4,6 +4,7 @@ import ida_segment
 import ida_bytes
 import idautils
 import json
+from collections import OrderedDict
 
 """
 Exports analysis data from IDA to a bnida json file
@@ -209,7 +210,7 @@ def get_structs():
     :return: Dict containing structure info
     """
 
-    structs = {}
+    structs = OrderedDict()
     for idx, sid, name in idautils.Structs():
         struct = ida_struct.get_struc(sid)
         structs[name] = {}


### PR DESCRIPTION
IDA contains types in its typelibs that it doesn't export using
IDAPython API's. If an exception is thrown when defining a struct
members type, I re-type it to be a byte array. Also, I've added
OrderedDict's to structure dictionaries in hope that it prevents types
from being applied out of order.

Closes #19