### PR TITLE
Improvements for Binja export -> IDA import workflow

### DIFF
--- a/binja/binja_export.py
+++ b/binja/binja_export.py
@@ -4,8 +4,10 @@ Exports analysis data from a BN database to a bnida JSON file
 
 import json
 from binaryninja import SaveFileNameField, get_form_input, BackgroundTaskThread, types
+from binaryninja.log import Logger
 from collections import OrderedDict
 
+logger = Logger(session_id=0, logger_name=__name__)
 
 class GetOptions(object):
     def __init__(self):
@@ -126,21 +128,32 @@ class ExportInBackground(BackgroundTaskThread):
         """
         Export analysis data to bnida JSON file
         """
-
-        print('[*] Exporting analysis data to {}'.format(
+        logger.log_info('[*] Exporting analysis data to {}'.format(
             self.options.json_file))
         json_array = {}
+
+        logger.log_debug("Exporting sections")
         json_array['sections'] = self.get_sections()
+
+        logger.log_debug("Exporting names")
         json_array['names'] = self.get_names()
+
+        logger.log_debug("Exporting functions")
         json_array['functions'] = self.get_functions()
+
+        logger.log_debug("Exporting function comments")
         json_array['func_comments'] = self.get_function_comments()
+
+        logger.log_debug("Exporting line comments")
         json_array['line_comments'] = self.get_line_comments()
+
+        logger.log_debug("Exporting structs")
         json_array['structs'] = self.get_structures()
 
         with open(self.options.json_file, 'w+') as f:
             json.dump(json_array, f, indent=4)
 
-        print('[+] Done exporting analysis data')
+        logger.log_info('[+] Done exporting analysis data')
 
 
 def export_data_in_background(bv):

--- a/binja/binja_export.py
+++ b/binja/binja_export.py
@@ -87,14 +87,9 @@ class ExportInBackground(BackgroundTaskThread):
 
         :return: Dict containing line comments
         """
-
         comments = {}
-        for section_name in self.bv.sections:
-            section = self.bv.get_section_by_name(section_name)
-            for addr in range(section.start, section.end):
-                comment = self.bv.get_comment_at(addr)
-                if comment:
-                    comments[addr] = comment
+        for addr in self.bv.address_comments:
+            comments[addr] = self.bv.get_comment_at(addr)
 
         for func in self.bv:
             for addr in func.comments:

--- a/ida/ida_import.py
+++ b/ida/ida_import.py
@@ -30,19 +30,6 @@ def get_flag_from_type(typ):
         return ida_bytes.byte_flag()
 
 
-def sanitize_name(name):
-    """
-    Remove characters from names that IDA doesn't like
-
-    :param name: Unsanitized name
-    :return: Sanitized name
-    """
-
-    name = name.replace('!', '_')
-    name = name.replace('@', '_')
-    return name
-
-
 def adjust_addr(sections, addr):
     """
     Adjust the address if there are differences in section base addresses
@@ -143,9 +130,9 @@ def import_names(names, sections):
         if addr is None:
             continue
 
-        name = sanitize_name(name)
         if idc.get_name_ea_simple(name) == idaapi.BADADDR:
-            idc.set_name(addr, name)
+            # Invalid characters are silently sanitized with `_` here.
+            idc.set_name(addr, name, idc.SN_NOCHECK)
 
 
 def import_structures(structures):


### PR DESCRIPTION
I've been using bnida to generate IDA databases from my Binary Ninja databases, for sharing analysis results with others who are using IDA. This PR adds some improvements specifically for that workflow.

The main issue I was running into with bnida was that for large binaries, the export from Binary Ninja would hang for a long time when trying to export line comments. [669ab3d](https://github.com/zznop/bnida/pull/28/commits/669ab3dee6d6969f317b06992c330c6c1b1456f7) should address this.